### PR TITLE
Dosent work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# eclipse
+# Eclipse.
 bin
 *.launch
 .settings
@@ -6,25 +6,25 @@ bin
 .classpath
 .project
 
-# idea
+# .idea
 out
 *.ipr
 *.iws
 *.iml
 .idea
 
-# gradle
+# Gradle.
 build
 .gradle
 
-# other
+# Other.
 eclipse
 run
 
-# Files from Forge MDK
+# Forge.
 forge*changelog.txt
 
-# version files
-src/main/java/me/earth/earthhack/impl/Earthhack.java
-src/main/resources/mcmod.info
-version
+*.DS_Store
+
+# Useless
+src/main/java/you/are/ratted/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Removed githash for ease of building (githash is useless)
 
+Yes, it is clean
+
 Windows: setupdecompworkspace, gradlew build
 
 Macos/Linux: ./setupdecompworkspace, ./gradlew build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Phobos/3arthh4ck 1.3.1
 
+Removed githash for ease of building (githash is useless)
+
 Windows: setupdecompworkspace, gradlew build
 
 Macos/Linux: ./setupdecompworkspace, ./gradlew build

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# 3arthh4ck
-The real phobos recode. Brought to you by oHareDaBoss himself.
+# Phobos/3arthh4ck 1.3.1 BUILDABLE-SRC
 
-released because grin is a big b word. very uncool of what he did.
-not swag.
-ohare.cc config provided because ohare.cc is the best server in mc.
-https://www.youtube.com/watch?v=xUyx8BdJ6JE
-the gui isn't bound by default so bind it with +bind clickgui rshift (+ is the default command prefix)
-every client bouta get a recode
+Windows: setupdecompworkspace, gradlew build
+
+Macos/Linux: ./setupdecompworkspace, ./gradlew build
+
+[Clean jar](https://github.com/Gopro336/clean-3arthh4ck-1.3.1/releases/tag/clean)

--- a/README.md
+++ b/README.md
@@ -3,5 +3,3 @@
 Windows: setupdecompworkspace, gradlew build
 
 Macos/Linux: ./setupdecompworkspace, ./gradlew build
-
-[Clean jar](https://github.com/Gopro336/clean-3arthh4ck-1.3.1/releases/tag/clean)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Phobos/3arthh4ck 1.3.1 BUILDABLE-SRC
+# Phobos/3arthh4ck 1.3.1
 
 Windows: setupdecompworkspace, gradlew build
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,93 +39,33 @@ apply plugin: 'eclipse'
 mainClassName = "me.earth.earthhack.installer.main.Main"
 group project.modGroup //http://maven.apache.org/guides/mini/guide-naming-conventions.html
 
-def getCheckedOutGitCommitHash() {
-    def gitFolder = "$projectDir/.git/"
-    def takeFromHash = 12
-    /*
-     * '.git/HEAD' contains either
-     *      in case of detached head: the currently checked out commit hash
-     *      otherwise: a reference to a file containing the current commit hash
-     */
-    def head = new File(gitFolder + "HEAD").text.split(":") // .git/HEAD
-    def isCommit = head.length == 1 // e5a7c79edabbf7dd39888442df081b1c9d8e88fd
-    // def isRef = head.length > 1     // ref: refs/heads/master
-
-    if(isCommit) return head[0].trim().take(takeFromHash) // e5a7c79edabb
-
-    def refHead = new File(gitFolder + head[1].trim()) // .git/refs/heads/master
-    refHead.text.trim().take takeFromHash
-}
+//def getCheckedOutGitCommitHash() {
+//    def gitFolder = "$projectDir/.git/"
+//    def takeFromHash = 12
+//    /*
+//     * '.git/HEAD' contains either
+//     *      in case of detached head: the currently checked out commit hash
+//     *      otherwise: a reference to a file containing the current commit hash
+//     */
+//    def head = new File(gitFolder + "HEAD").text.split(":") // .git/HEAD
+//    def isCommit = head.length == 1 // e5a7c79edabbf7dd39888442df081b1c9d8e88fd
+//    // def isRef = head.length > 1     // ref: refs/heads/master
+//
+//    if(isCommit) return head[0].trim().take(takeFromHash) // e5a7c79edabb
+//
+//    def refHead = new File(gitFolder + head[1].trim()) // .git/refs/heads/master
+//    refHead.text.trim().take takeFromHash
+//}
 
 // build constants
-
-boolean INCREMENT = false // increments version
-// NO APPEND THAT YOURSELF BITCH
-boolean UNIQUE = false // adds a random 8-char string to the build number
-// instead of incrementing the last number
-// this is so that we don't get absurdly large numbers
-// maybe only increment the number automatically if CI is ever added to the repo?
-boolean HASH = true
-boolean DATE = false // adds the date to the random string
 boolean CLEAR = true // clears other jars in the build folder to stop it from being clogged up
 
 boolean VANILLA = false
 
-String title = getCheckedOutGitCommitHash()
-
 //noinspection GroovyUnusedAssignment
 sourceCompatibility = targetCompatibility = '1.8'
 compileJava {
-    // idk this gets called when u do anything but whatever
-    File versionFile = file 'version'
-    String contents = versionFile.getText( 'UTF-8' )
-    String[] split = contents.split('\\.')
-    int lastVersion = Integer.parseInt(split[2].split('-')[0])
-    if (INCREMENT)
-    {
-        lastVersion++
-    }
-
-    if (!UNIQUE)
-    {
-        contents = split[0] + '.' + split[1] + '.' + (lastVersion)
-    }
-    else
-    {
-        String extra = ""
-        if (DATE)
-        {
-            Date date = Calendar.getInstance().getTime()
-            DateFormat dateFormat = new SimpleDateFormat('mm-dd-yy-hh-mm')
-            extra = dateFormat.format(date) + '-'
-        }
-
-        String generatedString = UUID.randomUUID().toString().split('-')[0]
-        String randomString = lastVersion + '-' + 'build-' + extra + generatedString
-        contents = split[0] + '.' + split[1] + '.' + randomString
-    }
-
-    if (HASH)
-    {
-        contents = split[0] + '.' + split[1] + '.' + lastVersion + '-' + title
-    }
-
-    versionFile.write( contents, 'UTF-8' )
-
-    version contents
-
     sourceCompatibility = targetCompatibility = '1.8'
-    // Tbh it would be much easier if we could assign this differently
-    // instead of writing it, but StackOverflow didn't give a working
-    // solution for that. One looked promising but it caused duplicate classes.
-    File update = file 'src/main/java/me/earth/earthhack/impl/Earthhack.java'
-    contents = update.getText( 'UTF-8' )
-    contents = contents.replaceAll( 'VERSION = "(.*?)"', 'VERSION = "' + project.version + '"' )
-    update.write( contents, 'UTF-8' )
-    update = file 'src/main/resources/mcmod.info'
-    contents = update.getText( 'UTF-8' )
-    contents = contents.replaceAll( '"version": "(.*?)"', '"version": "' + project.version + '"' )
-    update.write( contents, 'UTF-8' )
 
     if (CLEAR)
     {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Dec 07 17:56:36 EST 2021
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-bin.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/me/earth/earthhack/impl/Earthhack.java
+++ b/src/main/java/me/earth/earthhack/impl/Earthhack.java
@@ -14,7 +14,8 @@ public class Earthhack
         implements Globals {
     private static final Logger LOGGER = LogManager.getLogger((String)"3arthh4ck");
     public static final String NAME = "3arthh4ck";
-    public static final String VERSION = "1.3.1-09dc40abfd7b";
+    public static final String VERSION = "1.3.1";
+//    public static final String VERSION = "1.3.1-2b8b477067fb";
 
     public static void preInit() {
         GlobalExecutor.EXECUTOR.submit(() -> Sphere.cacheSphere(LOGGER));
@@ -30,7 +31,6 @@ public class Earthhack
 
     public static void postInit() {
     }
-
 
     public static Logger getLogger() {
         return LOGGER;

--- a/src/main/java/me/earth/earthhack/installer/version/Version.java
+++ b/src/main/java/me/earth/earthhack/installer/version/Version.java
@@ -1,30 +1,35 @@
+/*
+ * Decompiled with CFR 0.150.
+ * 
+ * Could not load the following classes:
+ *  com.google.gson.JsonObject
+ */
 package me.earth.earthhack.installer.version;
 
-import com.google.gson.*;
-
+import com.google.gson.JsonObject;
 import java.io.File;
 
-public class Version
-{
+public class Version {
     private final String name;
     private final File file;
     private final JsonObject json;
-    
-    public Version(final String name, final File file, final JsonObject json) {
+
+    public Version(String name, File file, JsonObject json) {
         this.name = name;
         this.file = file;
         this.json = json;
     }
-    
+
     public String getName() {
         return this.name;
     }
-    
+
     public File getFile() {
         return this.file;
     }
-    
+
     public JsonObject getJson() {
         return this.json;
     }
 }
+

--- a/src/main/java/me/earth/earthhack/installer/version/VersionFinder.java
+++ b/src/main/java/me/earth/earthhack/installer/version/VersionFinder.java
@@ -1,44 +1,44 @@
+/*
+ * Decompiled with CFR 0.150.
+ * 
+ * Could not load the following classes:
+ *  com.google.gson.JsonObject
+ */
 package me.earth.earthhack.installer.version;
 
-import com.google.gson.*;
-import me.earth.earthhack.api.config.Jsonable;
-import me.earth.earthhack.installer.main.MinecraftFiles;
-
+import com.google.gson.JsonObject;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
+import me.earth.earthhack.api.config.Jsonable;
+import me.earth.earthhack.installer.main.MinecraftFiles;
+import me.earth.earthhack.installer.version.Version;
 
-public class VersionFinder
-{
-    public List<Version> findVersions(final MinecraftFiles files) throws IOException {
-        final File[] versionFolders = new File(files.getVersions()).listFiles();
+public class VersionFinder {
+    public List<Version> findVersions(MinecraftFiles files) throws IOException {
+        File[] versionFolders = new File(files.getVersions()).listFiles();
         if (versionFolders == null) {
             throw new IllegalStateException("Version folder was empty!");
         }
-        final List<Version> result = new ArrayList<Version>();
-        for (final File file : versionFolders) {
-            if (file.getName().startsWith("1.12.2")) {
-                if (file.isDirectory()) {
-                    final File[] contained = file.listFiles();
-                    if (contained != null) {
-                        for (final File json : contained) {
-                            if (json.getName().endsWith("json")) {
-                                final Version version = this.readJson(file.getName(), json);
-                                result.add(version);
-                            }
-                        }
-                    }
-                }
+        ArrayList<Version> result = new ArrayList<Version>();
+        for (File file : versionFolders) {
+            File[] contained;
+            if (!file.getName().startsWith("1.12.2") || !file.isDirectory() || (contained = file.listFiles()) == null) continue;
+            for (File json : contained) {
+                if (!json.getName().endsWith("json")) continue;
+                Version version = this.readJson(file.getName(), json);
+                result.add(version);
             }
         }
         return result;
     }
-    
-    private Version readJson(final String name, final File jsonFile) throws IOException {
-        final JsonObject object = Jsonable.PARSER.parse((Reader)new InputStreamReader(jsonFile.toURI().toURL().openStream())).getAsJsonObject();
+
+    private Version readJson(String name, File jsonFile) throws IOException {
+        JsonObject object = Jsonable.PARSER.parse((Reader)new InputStreamReader(jsonFile.toURI().toURL().openStream())).getAsJsonObject();
         return new Version(name, jsonFile, object);
     }
 }
+

--- a/src/main/java/me/earth/earthhack/installer/version/VersionUtil.java
+++ b/src/main/java/me/earth/earthhack/installer/version/VersionUtil.java
@@ -1,39 +1,54 @@
+/*
+ * Decompiled with CFR 0.150.
+ * 
+ * Could not load the following classes:
+ *  com.google.gson.JsonElement
+ *  com.google.gson.JsonObject
+ */
 package me.earth.earthhack.installer.version;
 
-import com.google.gson.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import me.earth.earthhack.api.config.Jsonable;
+import me.earth.earthhack.installer.version.Version;
 
-public class VersionUtil
-{
+public class VersionUtil {
     public static final String MAIN = "net.minecraft.launchwrapper.Launch";
     public static final String EARTH = "--tweakClass me.earth.earthhack.tweaker.EarthhackTweaker";
     public static final String FORGE = "--tweakClass net.minecraftforge.fml.common.launcher.FMLTweaker";
     public static final String ARGS = "minecraftArguments";
     public static final String LIBS = "libraries";
-    
-    public static boolean hasEarthhack(final Version version) {
-        return containsArgument(version, "--tweakClass me.earth.earthhack.tweaker.EarthhackTweaker");
+
+    public static boolean hasEarthhack(Version version) {
+        return VersionUtil.containsArgument(version, EARTH);
     }
-    
-    public static boolean hasForge(final Version version) {
-        return containsArgument(version, "--tweakClass net.minecraftforge.fml.common.launcher.FMLTweaker");
+
+    public static boolean hasForge(Version version) {
+        return VersionUtil.containsArgument(version, FORGE);
     }
-    
-    public static boolean hasLaunchWrapper(final Version version) {
-        final JsonElement element = version.getJson().get("mainClass");
-        return element != null && element.getAsString().equals("net.minecraft.launchwrapper.Launch");
+
+    public static boolean hasLaunchWrapper(Version version) {
+        JsonElement element = version.getJson().get("mainClass");
+        if (element != null) {
+            return element.getAsString().equals(MAIN);
+        }
+        return false;
     }
-    
-    public static boolean containsArgument(final Version version, final String tweaker) {
-        final JsonElement element = version.getJson().get("minecraftArguments");
-        return element != null && element.getAsString().contains(tweaker);
+
+    public static boolean containsArgument(Version version, String tweaker) {
+        JsonElement element = version.getJson().get(ARGS);
+        if (element != null) {
+            return element.getAsString().contains(tweaker);
+        }
+        return false;
     }
-    
-    public static JsonElement getOrElse(final String name, final JsonObject object, final String returnElse) {
-        final JsonElement element = object.get(name);
+
+    public static JsonElement getOrElse(String name, JsonObject object, String returnElse) {
+        JsonElement element = object.get(name);
         if (element == null) {
             return Jsonable.PARSER.parse(returnElse);
         }
         return element;
     }
 }
+

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,0 +1,16 @@
+[
+{
+  "modid": "earthhack",
+  "name": "3arthh4ck",
+  "description": "A 1.12.2 Anarchy Client.",
+  "version": "1.3.1-2b8b477067fb",
+  "mcversion": "1.12.2",
+  "url": "",
+  "updateUrl": "",
+  "authorList": ["3arthqu4ke","Gerald"],
+  "credits": "Phobos",
+  "logoFile": "",
+  "screenshots": [],
+  "dependencies": []
+}
+]


### PR DESCRIPTION
It shows this
Info: Java arguments: [-Djava.awt.headless=false, -Dcacio.managed.screensize=2000x1200, -Dcacio.font.fontmanager=sun.awt.X11FontManager, -Dcacio.font.fontscaler=sun.font.FreetypeFontScaler, -Dswing.defaultlaf=javax.swing.plaf.metal.MetalLookAndFeel, -Dawt.toolkit=net.java.openjdk.cacio.ctc.CTCToolkit, -Djava.awt.graphicsenv=net.java.openjdk.cacio.ctc.CTCGraphicsEnvironment, -Xbootclasspath/p:/storage/emulated/0/Android/data/net.kdt.pojavlaunch/files/caciocavallo/ResConfHack.jar:/storage/emulated/0/Android/data/net.kdt.pojavlaunch/files/caciocavallo/cacio-androidnw-1.10-SNAPSHOT.jar:/storage/emulated/0/Android/data/net.kdt.pojavlaunch/files/caciocavallo/cacio-shared-1.10-SNAPSHOT.jar, -jar, /data/user/0/net.kdt.pojavlaunch/cache/3arthh4ck_1.3.1-release.jar]
Added custom env: TMPDIR=/data/user/0/net.kdt.pojavlaunch/cache
Added custom env: AWTSTUB_WIDTH=2000
Added custom env: REGAL_GL_VERSION=4.5
Added custom env: REGAL_GL_VENDOR=Android
Added custom env: LIBGL_MIPMAP=3
Added custom env: allow_higher_compat_version=true
Added custom env: MESA_GLSL_CACHE_DIR=/data/user/0/net.kdt.pojavlaunch/cache
Added custom env: HOME=/storage/emulated/0/Android/data/net.kdt.pojavlaunch/files/.minecraft
Added custom env: PATH=/data/user/0/net.kdt.pojavlaunch/runtimes/Internal/bin:/product/bin:/apex/com.android.runtime/bin:/apex/com.android.art/bin:/system_ext/bin:/system/bin:/system/xbin:/odm/bin:/vendor/bin:/vendor/xbin
Added custom env: force_glsl_extensions_warn=true
Added custom env: LIBGL_NORMALIZE=1
Added custom env: LD_LIBRARY_PATH=/data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/jli:/data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64:/system/lib64:/vendor/lib64:/vendor/lib64/hw:/data/app/~~ikuqDHYiFFmCIO47NOBH_g==/net.kdt.pojavlaunch-kZCI-XpYk3NzVA3wfN3pYA==/lib/arm64
Added custom env: MESA_LOADER_DRIVER_OVERRIDE=zink
Added custom env: MESA_GLSL_VERSION_OVERRIDE=460
Added custom env: JAVA_HOME=/data/user/0/net.kdt.pojavlaunch/runtimes/Internal
Added custom env: MESA_GL_VERSION_OVERRIDE=4.6
Added custom env: allow_glsl_extension_directive_midshader=true
Added custom env: REGAL_GL_RENDERER=Regal
Added custom env: AWTSTUB_HEIGHT=1200
OpenJDK 64-Bit Server VM warning: No monotonic clock was available - timed services may be adversely affected if the time-of-day clock changes
Policy policy.url.2=file:/storage/emulated/0/Android/data/net.kdt.pojavlaunch/files/.java.policy wasn't successfully parsed. Exception message: /storage/emulated/0/Android/data/net.kdt.pojavlaunch/files/.java.policy (No such file or directory)

Unable to initialize policy entry: Illegal character in opaque part at index 6: file:${{java.ext.dirs}}/*

--------- beginning of main
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libnet.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libnio.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libawt.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libawt_headless.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libfreetype.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libfontmanager.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libjsound.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libjpeg.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libawt.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/jli/libjli.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/server/libjvm.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libjsdt.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libfontmanager.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libj2pcsc.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libmanagement.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libunpack.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libjaas_unix.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libhprof.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libfreetype.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libawt_xawt.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libjsig.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libj2gss.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libsunec.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libnpt.so failed: dlopen failed: library "libtinyiconv.so" not found: needed by /data/data/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libnpt.so in namespace classloader-namespace
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libnet.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libjava_crw_demo.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libjava.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libnio.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libtinyiconv.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libj2pkcs11.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libdt_socket.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libjdwp.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libzip.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libsctp.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libmlib_image.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libinstrument.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/liblcms.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libjawt.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libverify.so success
I/jrelog (25237): dlopen /data/user/0/net.kdt.pojavlaunch/runtimes/Internal/lib/aarch64/libawt_headless.so success
I/jrelog (25237): dlopen /data/app/~~ikuqDHYiFFmCIO47NOBH_g==/net.kdt.pojavlaunch-kZCI-XpYk3NzVA3wfN3pYA==/lib/arm64/libopenal.so success
I/jrelog (25237): Done processing args
I/jrelog (25237): Found JLI lib
I/jrelog (25237): Calling JLI_Launch
java.lang.NoClassDefFoundError: com/google/gson/JsonParser

at me.earth.earthhack.api.config.Jsonable.<clinit>(Jsonable.java:18)
at me.earth.earthhack.installer.version.VersionFinder.readJson(VersionFinder.java:40)
at me.earth.earthhack.installer.version.VersionFinder.findVersions(VersionFinder.java:32)
at me.earth.earthhack.installer.EarthhackInstaller.lambda$refreshVersions$1(EarthhackInstaller.java:60)
at me.earth.earthhack.installer.EarthhackInstaller.wrapErrorGui(EarthhackInstaller.java:100)
at me.earth.earthhack.installer.EarthhackInstaller.refreshVersions(EarthhackInstaller.java:57)
at me.earth.earthhack.installer.EarthhackInstaller.lambda$launch$0(EarthhackInstaller.java:50)
at me.earth.earthhack.installer.EarthhackInstaller.wrapErrorGui(EarthhackInstaller.java:100)
at me.earth.earthhack.installer.EarthhackInstaller.launch(EarthhackInstaller.java:39)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:498)

at me.earth.earthhack.installer.main.Main.main(Main.java:57)
Caused by: java.lang.ClassNotFoundException: Could not find com.google.gson.JsonParser
at me.earth.earthhack.installer.main.LibraryClassLoader.loadClass(LibraryClassLoader.java:69)
at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
... 14 more
--------- beginning of system